### PR TITLE
Changed structs to classes so that it builds in Swift 5.5

### DIFF
--- a/bslox/Chunk.swift
+++ b/bslox/Chunk.swift
@@ -8,17 +8,17 @@
 
 import Foundation
 
-struct Chunk {
+final class Chunk {
     var codes: [OpCode] = []
     var lines = CompressedArray<Int>()
     var constants: [Value] = []
     
-    mutating func write(_ op: OpCode, line: Int) {
+    func write(_ op: OpCode, line: Int) {
         codes.append(op)
         lines.append(line)
     }
     
-    mutating func addConstant(_ value: Value) -> UInt8 {
+    func addConstant(_ value: Value) -> UInt8 {
         constants.append(value)
         return UInt8(constants.count - 1)
     }

--- a/bslox/Compiler.swift
+++ b/bslox/Compiler.swift
@@ -12,8 +12,8 @@ import Darwin
 import Glibc
 #endif
 
-func compile(_ source: String, _ chunk: inout Chunk) -> Bool {
-    var scanner = Scanner(source)
+func compile(_ source: String, _ chunk: Chunk) -> Bool {
+    let scanner = Scanner(source)
     
     struct Parser {
         var previous: Token

--- a/bslox/Scanner.swift
+++ b/bslox/Scanner.swift
@@ -35,7 +35,7 @@ struct Token {
     let line: Int
 }
 
-struct Scanner {
+final class Scanner {
     private let source: String
     private var start: String.UnicodeScalarIndex
     private var current: String.UnicodeScalarIndex
@@ -68,20 +68,20 @@ struct Scanner {
     
     var text: Substring { return source[start..<current] }
     
-    @discardableResult private mutating func advance() -> UnicodeScalar {
+    @discardableResult private func advance() -> UnicodeScalar {
         let result = source.unicodeScalars[current]
         current = source.unicodeScalars.index(after: current)
         return result
     }
     
-    private mutating func match(_ expected: UnicodeScalar) -> Bool {
+    private func match(_ expected: UnicodeScalar) -> Bool {
         if isAtEnd { return false }
         guard source.unicodeScalars[current] == expected else { return false }
         current = source.unicodeScalars.index(after: current)
         return true
     }
     
-    private mutating func skipWhitespace() {
+    private func skipWhitespace() {
         while true {
             switch peek {
             case " ": fallthrough
@@ -101,7 +101,7 @@ struct Scanner {
         }
     }
     
-    mutating func scanToken() -> Token {
+    func scanToken() -> Token {
         skipWhitespace()
         start = current
         
@@ -142,7 +142,7 @@ struct Scanner {
         return errorToken("Unexpected character")
     }
     
-    private mutating func string() -> Token {
+    private func string() -> Token {
         while peek != "\"" && !isAtEnd {
             if peek == "\n" { line += 1 }
             advance()
@@ -155,7 +155,7 @@ struct Scanner {
         return makeToken(.string)
     }
     
-    private mutating func number() -> Token {
+    private func number() -> Token {
         while peek.isDigit { advance() }
         
         // Look for a fractional part.
@@ -169,7 +169,7 @@ struct Scanner {
         return makeToken(.number)
     }
     
-    private mutating func identifier() -> Token {
+    private func identifier() -> Token {
         while peek.isAlpha || peek.isDigit { advance() }
 
         let keywords: [String: TokenType] = [

--- a/bslox/VM.swift
+++ b/bslox/VM.swift
@@ -23,9 +23,9 @@ struct VM {
     }
 
     mutating func interpret(_ source: String) -> InterpretResult {
-        var newChunk = Chunk()
+        let newChunk = Chunk()
         
-        guard compile(source, &newChunk) else {
+        guard compile(source, newChunk) else {
             return .compileError
         }
         


### PR DESCRIPTION
It wouldn't build for Swift 5.5. Changing structs to classes fixed the issue, but it isn't a great solution. Just putting this here for those who might want to try compiling this quickly in Swift 5.5